### PR TITLE
On left click trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ Example code is available [here](https://github.com/reachtokish/rctx-contextmenu
       <td>Disable contextmenu and open browser default contextmenu.</td>
     </tr>
     <tr>
+      <td>onLeftClick</td>
+      <td>true / false. <strong>Default: false</strong></td>
+      <td>false</td>
+      <td>contextMenu will trigger on left click instead of Right</td>
+    </tr>
+    <tr>
       <td>className</td>
       <td>String</td>
       <td>-</td>

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   ExampleOne, ExampleTwo, ExampleThree, ExampleFour, ExampleFive, ExampleSix,
-  ExampleSeven
+  ExampleSeven, ExampleEight
 } from 'example/src/examples';
 import forkRibbon from './assets/images/fork-ribbon.png';
 
@@ -46,6 +46,10 @@ const Demo = () => {
 
             <div className="content__section">
               <ExampleSeven />
+            </div>
+
+            <div className="content__section">
+              <ExampleEight />
             </div>
 
           </div>

--- a/example/src/examples/example8.js
+++ b/example/src/examples/example8.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { ContextMenu, ContextMenuItem, ContextMenuTrigger } from 'src';
+import { MusicIcon } from '../icons';
+import tracks from '../tracks';
+import playIcon from '../assets/images/menu-icons/interface.svg';
+import addToList from '../assets/images/menu-icons/multimedia.svg';
+import openWith from '../assets/images/menu-icons/shapes-and-symbols.svg';
+import deleteIco from '../assets/images/menu-icons/delete.svg';
+import copy from '../assets/images/menu-icons/copy.svg';
+import rename from '../assets/images/menu-icons/tool.svg';
+import restore from '../assets/images/menu-icons/ui.svg';
+import send from '../assets/images/menu-icons/communications.svg';
+import scan from '../assets/images/menu-icons/miscellaneous.svg';
+import properties from '../assets/images/menu-icons/commerce-and-shopping.svg';
+
+function ExampleEight() {
+  return (
+    <div>
+      <h2 className="title">
+        Left Click Trigger Example
+      </h2>
+      <div className="music-box-holder">
+        {tracks.map(({ id, trackName, artist, album, duration }) => (
+          <ContextMenuTrigger onLeftClick={true} id="context-menu-8" className="music-box" key={id}>
+            <div className="music-box-left">
+              <div className="music-icon">
+                <MusicIcon />
+              </div>
+              <p>MP3</p>
+            </div>
+            <div className="music-box-right">
+              <h3>{trackName}</h3>
+              <p>{artist}</p>
+              <p>{album}</p>
+              <span>{duration}</span>
+            </div>
+          </ContextMenuTrigger>
+        ))}
+      </div>
+      <ContextMenu id="context-menu-8">
+        <ContextMenuItem>
+          <img src={playIcon} alt="ico" />
+          Play
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={addToList} alt="Ico" />
+          Add to Media Player List
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={openWith} alt="Ico" />
+          Open With...
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={deleteIco} alt="Ico" />
+          Delete
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={copy} alt="Ico" />
+          Copy
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={rename} alt="Ico" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem disabled={true}>
+          <img src={restore} alt="Ico" />
+          Restore Previous Version
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={send} alt="Ico" />
+          Send to
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={scan} alt="Ico" />
+          Scan with Windows Defender
+        </ContextMenuItem>
+        <ContextMenuItem>
+          <img src={properties} alt="Ico" />
+          Properties
+        </ContextMenuItem>
+      </ContextMenu>
+    </div>
+  )
+}
+
+export default ExampleEight;

--- a/example/src/examples/index.js
+++ b/example/src/examples/index.js
@@ -5,3 +5,4 @@ export { default as ExampleFour } from './example4';
 export { default as ExampleFive } from './example5';
 export { default as ExampleSix } from './example6';
 export { default as ExampleSeven } from './example7';
+export { default as ExampleEight } from './example8';

--- a/src/contextMenuTrigger.js
+++ b/src/contextMenuTrigger.js
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { callShowEvent, callHideEvent } from './registerEvent';
 
 function ContextMenuTrigger({
-  children, id, disableWhileShiftPressed, attributes, disable, className
+  children, id, disableWhileShiftPressed, onLeftClick, attributes, disable, className
 }) {
   const menuTrigger = useRef(null);
 
@@ -33,7 +33,8 @@ function ContextMenuTrigger({
       className={classnames('menu-trigger', ...className.split(' '))}
       ref={menuTrigger}
       {...attributes}
-      onContextMenu={e => handleContextMenu(e)}
+      onClick={e => (onLeftClick ? handleContextMenu(e) : undefined)}
+      onContextMenu={e => (!onLeftClick ? handleContextMenu(e) : undefined)}
     >
       {children}
     </div>
@@ -45,6 +46,7 @@ export default ContextMenuTrigger;
 ContextMenuTrigger.defaultProps = {
   attributes: {},
   disable: false,
+  onLeftClick: false,
   renderTag: 'div',
   disableWhileShiftPressed: false,
   className: ''


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
I've added a boolean value for the Left mouse button, if this is set to true, the ContextMenuTrigger will not respond to right clicks, but left clicks. I've also updated the example files, so that there's a left-click example. This can be removed if needed.

<!-- Why are these changes necessary? -->

**Why**:
This lowers the amount of bloat in a personal project im working on, this simple addition removes the need for left-click menu's as this package will be able to support it instead.

<!-- How were these changes implemented? -->

**How**:
I've added a boolean value to the `<ContextMenuTrigger />` function, if this is set to true (onLeftClick) the context menu will trigger on Left Click instead of Right Click.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
If you have any feedback i'd love to hear it 👍 