### PR TITLE
Arrow functions do not have an arguments object

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -5,9 +5,8 @@ export const uniqueId = () => `_${Math.random().toString(36).substr(2, 9)}`;
 export const throttle = (func, limit) => {
   let lastFunc;
   let lastRan;
-  return () => {
+  return (...args) => {
     const context = window;
-    const args = arguments;
     if (!lastRan) {
       func.apply(context, args);
       lastRan = Date.now();


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

Arrow functions don't have their own bindings to this, arguments, or super, and should not be used as methods.